### PR TITLE
:sparkles: handle absolute paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-workbench",
-  "version": "1.0.0",
+  "name": "zenika-react-workbench",
+  "version": "0.0.1",
   "main": "src/index.js",
   "repository": "git@github.com:Zenika/react-workbench.git",
   "license": "MIT",
@@ -62,7 +62,8 @@
       "import/extensions": 0,
       "func-names": 0,
       "jsx-a11y/no-static-element-interactions": 0,
-      "react/no-danger": 0
+      "react/no-danger": 0,
+      "no-await-in-loop": 0
     }
   },
   "babel": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "babel-core": "^6.24.0",
     "babel-loader": "^6.4.1",
+    "babel-plugin-react-docgen": "^1.4.2",
     "babel-plugin-syntax-class-properties": "^6.13.0",
     "babel-plugin-transform-class-properties": "^6.23.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.24.0",
@@ -25,7 +26,9 @@
     "babel-preset-react": "^6.23.0",
     "bluebird": "^3.5.0",
     "css-loader": "^0.28.0",
+    "hoc-react-datgui": "^0.0.2",
     "html-webpack-plugin": "^2.28.0",
+    "lodash": "^4.17.4",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-redux": "^5.0.3",
@@ -64,29 +67,6 @@
       "jsx-a11y/no-static-element-interactions": 0,
       "react/no-danger": 0,
       "no-await-in-loop": 0
-    }
-  },
-  "babel": {
-    "plugins": [
-      "transform-class-properties",
-      "transform-object-rest-spread"
-    ],
-    "presets": [
-      "es2017",
-      [
-        "es2015",
-        {
-          "modules": false
-        }
-      ],
-      "react"
-    ],
-    "env": {
-      "test": {
-        "plugins": [
-          "transform-es2015-modules-commonjs"
-        ]
-      }
     }
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -5,14 +5,40 @@ const Promise = require('bluebird')
 const fs = Promise.promisifyAll(require('fs'))
 const webpackDevServer = require('./webpack')
 
+const getDirectories = async (filePath) => {
+  const paths = []
+  let previousPath = path.dirname(filePath)
+  let files = await fs.readdirAsync(previousPath)
+
+  // looking for the first directory with a 'package.json' file
+  while (!files.includes('package.json')) {
+    previousPath = path.resolve(previousPath, '..')
+    files = await fs.readdirAsync(previousPath)
+  }
+  paths.push(`${previousPath}/node_modules`)
+  paths.push(previousPath)
+
+  // from the directory found (package.json one)
+  // 1. looking for a 'src' directory
+  if (files.includes('src')) paths.push(path.resolve(previousPath, 'src'))
+  // 2. looking for a 'webpack.config.js' file
+  // TODO : retrieve resolve from this configuration file
+  // if (files.includes('webpack.config.js'))
+  // 3. looking for a 'style' directory
+  if (files.includes('styles')) paths.push(path.resolve(previousPath, 'styles'))
+
+  return paths
+}
+
 const start = async (component) => {
   // 1. Read the template file
   const filePath = path.resolve(__dirname, 'template.jsx')
   const template = await fs.readFileAsync(filePath, 'utf-8')
 
   // 2. Replace what needs to be replaced
-  const componentPath = path.relative(__dirname, path.resolve(process.env.PWD, component))
-  const appFileContent = template.replace('/* react-workbench-insert import */', componentPath)
+  const componentPath = path.resolve(process.env.PWD, component)
+  const relativeComponentPath = path.relative(__dirname, componentPath)
+  const appFileContent = template.replace('/* react-workbench-insert import */', relativeComponentPath)
 
   // 3. Write it into a tmp folder
   // 3.a Create the tmp folder
@@ -26,10 +52,13 @@ const start = async (component) => {
   }
 
   // 3.b Write file
-  await fs.writeFileAsync(path.resolve(output.dir, output.file), appFileContent)
+  const fullpath = path.resolve(output.dir, output.file)
+  await fs.writeFileAsync(fullpath, appFileContent)
 
   // 4. Start webpack-dev-server
-  webpackDevServer.start()
+  // retrieve important directories and files (module, source, webpack conf, etc)
+  // and start the server
+  webpackDevServer.start(await getDirectories(componentPath))
 }
 
 start(process.argv[2])

--- a/src/template.jsx
+++ b/src/template.jsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { render } from 'react-dom'
 import { createStore, compose } from 'redux'
 import { Provider } from 'react-redux'
+import mapValues from 'lodash/mapValues'
+import { withDatGui } from 'hoc-react-datgui'
 
 // eslint-disable-next-line import/no-absolute-path
 import Component from '/* react-workbench-insert import */'
@@ -23,9 +25,21 @@ const store = createStore(
 )
 // --- !! REDUX
 
+/* eslint-disable no-underscore-dangle, no-eval */
+// get component info and generate datgui
+const model = mapValues(
+  Component.__docgenInfo.props,
+  value => ({
+    type: value.type.name,
+    defaultValue: eval(value.defaultValue && value.defaultValue.value),
+  }),
+)
+const WrappedComponent = withDatGui(Component, model)
+/* eslint-enable no-underscore-dangle, no-eval */
+
 const App = () => (
   <Provider store={store}>
-    <Component />
+    <WrappedComponent />
   </Provider>
 )
 

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -5,6 +5,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 
 module.exports = {
   devtool: 'eval',
+  context: path.resolve(__dirname, '..'),
   entry: {
     app: [
       path.resolve(__dirname, '..', 'tmp', 'index.jsx'),
@@ -35,7 +36,28 @@ module.exports = {
         exclude: [
           /node_modules/,
         ],
-        use: ['babel-loader'],
+        use: {
+          loader: 'babel-loader',
+          options: {
+            plugins: [
+              /* eslint-disable global-require */
+              require('babel-plugin-react-docgen').default,
+              require('babel-plugin-transform-class-properties'),
+              require('babel-plugin-transform-object-rest-spread'),
+              /* eslint-enable global-require */
+            ],
+            presets: [
+              'es2017',
+              [
+                'es2015',
+                {
+                  modules: false,
+                },
+              ],
+              'react',
+            ],
+          },
+        },
       },
       {
         test: /\.scss?$/,

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -17,6 +17,9 @@ module.exports = {
   },
   resolve: {
     extensions: ['.js', '.jsx', '.scss'],
+    modules: [
+      'node_modules',
+    ],
   },
   plugins: [
     new HtmlWebpackPlugin({

--- a/src/webpack.js
+++ b/src/webpack.js
@@ -4,8 +4,11 @@ const config = require('./webpack.config.js')
 
 const WEBPACK_PORT = 8080
 
-const start = () => {
+const start = (paths) => {
+  // patch config
   config.entry.app.unshift(`webpack-dev-server/client?http://localhost:${WEBPACK_PORT}/`)
+  config.resolve.modules = config.resolve.modules.concat(paths)
+
   const compiler = webpack(config)
   const server = new WebpackDevServer(compiler)
   server.listen(WEBPACK_PORT)

--- a/yarn.lock
+++ b/yarn.lock
@@ -191,11 +191,15 @@ ast-types-flow@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
 
+ast-types@0.9.6:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
+
 async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
-async@^1.5.2:
+async@^1.4.2, async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
@@ -396,6 +400,14 @@ babel-plugin-check-es2015-constants@^6.22.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
   dependencies:
     babel-runtime "^6.22.0"
+
+babel-plugin-react-docgen@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-react-docgen/-/babel-plugin-react-docgen-1.4.2.tgz#04c02133b84b6cc182d35de2162f15764da03e7c"
+  dependencies:
+    babel-types "^6.16.0"
+    lodash "4.x.x"
+    react-docgen "^2.12.1"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -726,7 +738,7 @@ babel-register@^6.24.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.18.0, babel-runtime@^6.22.0:
+babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.9.2:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
@@ -757,7 +769,7 @@ babel-traverse@^6.22.0, babel-traverse@^6.23.0, babel-traverse@^6.23.1:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23.0:
+babel-types@^6.16.0, babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.23.0.tgz#bb17179d7538bad38cd0c9e115d340f77e7e9acf"
   dependencies:
@@ -769,6 +781,10 @@ babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23.0:
 babylon@^6.11.0, babylon@^6.15.0, babylon@^6.16.1:
   version "6.16.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.16.1.tgz#30c5a22f481978a9e7f8cdfdf496b11d94b404d3"
+
+babylon@~5.8.3:
+  version "5.8.38"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-5.8.38.tgz#ec9b120b11bf6ccd4173a18bf217e60b79859ffd"
 
 balanced-match@^0.4.1, balanced-match@^0.4.2:
   version "0.4.2"
@@ -1117,7 +1133,7 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.9.x:
+commander@2.9.x, commander@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -1375,6 +1391,10 @@ dashdash@^1.12.0:
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
+
+"dat.gui@github:dataarts/dat.gui":
+  version "0.6.3"
+  resolved "https://codeload.github.com/dataarts/dat.gui/tar.gz/ab80fca553251ed5da1c1e725e162fa8cc57b526"
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -1803,7 +1823,7 @@ esprima@^2.6.0:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
 
-esprima@^3.1.1:
+esprima@^3.1.1, esprima@~3.1.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
@@ -2253,6 +2273,13 @@ hmac-drbg@^1.0.0:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
+
+hoc-react-datgui@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/hoc-react-datgui/-/hoc-react-datgui-0.0.2.tgz#bc93785c2c4df124efca614c68a1d880c6c7fe95"
+  dependencies:
+    dat.gui dataarts/dat.gui
+    lodash "^4.17.4"
 
 hoek@2.x.x:
   version "2.16.3"
@@ -2843,7 +2870,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
+lodash@4.x.x, lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -3008,6 +3035,12 @@ no-case@^2.2.0:
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.1.tgz#7aeba1c73a52184265554b7dc03baf720df80081"
   dependencies:
     lower-case "^1.1.1"
+
+node-dir@^0.1.10:
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.16.tgz#d2ef583aa50b90d93db8cdd26fcea58353957fe4"
+  dependencies:
+    minimatch "^3.0.2"
 
 node-fetch@^1.0.1:
   version "1.6.3"
@@ -3618,7 +3651,7 @@ pretty-error@^2.0.2:
     renderkid "^2.0.1"
     utila "~0.4"
 
-private@^0.1.6:
+private@^0.1.6, private@~0.1.5:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
 
@@ -3730,6 +3763,18 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-docgen@^2.12.1:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-2.13.0.tgz#7fcc4a3104ea8d4fd428383ba38df11166837be9"
+  dependencies:
+    async "^1.4.2"
+    babel-runtime "^6.9.2"
+    babylon "~5.8.3"
+    commander "^2.9.0"
+    doctrine "^2.0.0"
+    node-dir "^0.1.10"
+    recast "^0.11.5"
+
 react-dom@^15.4.2:
   version "15.4.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.4.2.tgz#015363f05b0a1fd52ae9efdd3a0060d90695208f"
@@ -3816,6 +3861,15 @@ readline2@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
+
+recast@^0.11.5:
+  version "0.11.23"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.11.23.tgz#451fd3004ab1e4df9b4e4b66376b2a21912462d3"
+  dependencies:
+    ast-types "0.9.6"
+    esprima "~3.1.0"
+    private "~0.1.5"
+    source-map "~0.5.0"
 
 rechoir@^0.6.2:
   version "0.6.2"
@@ -4199,7 +4253,7 @@ source-map-support@^0.4.2:
   dependencies:
     source-map "^0.5.6"
 
-source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3:
+source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.0, source-map@~0.5.1, source-map@~0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 


### PR DESCRIPTION
## TODOs in this PR
- [ ] move `getDirectories` to webpack.js ?
- [ ] retrieve the webpack.config.js config file from the component to test
- [ ] delete the force push of 'src' and 'styles'

## TODO in issues (??)
- [x] The workbench works (find its modules) when the test directory is **inside** the workbench but doesn't when this is a sibling. This is thanks to how node works (node look for parents node_modules directories). This is **not** we want workbench to work