### PR TITLE
:sparkles: display documentation in gui

### DIFF
--- a/src/gui/redux/documentation/documentation.actions.js
+++ b/src/gui/redux/documentation/documentation.actions.js
@@ -1,0 +1,15 @@
+export const REQUEST_DOCUMENTATION = 'REQUEST_DOCUMENTATION'
+export const RECEIVED_DOCUMENTATION = 'RECEIVED_DOCUMENTATION'
+export const RECEIVED_EMPTY_DOCUMENTATION = 'RECEIVED_EMPTY_DOCUMENTATION'
+export const FAILED_DOCUMENTATION = 'FAILED_DOCUMENTATION'
+
+export const fetchDocumentation = () => async (dispatch) => {
+  dispatch({ type: REQUEST_DOCUMENTATION })
+  try {
+    const response = await fetch('/api/doc?format=markdown')
+    const text = await response.text()
+    dispatch({ type: RECEIVED_DOCUMENTATION, payload: text })
+  } catch (error) {
+    dispatch({ type: FAILED_DOCUMENTATION, error })
+  }
+}

--- a/src/gui/redux/documentation/documentation.js
+++ b/src/gui/redux/documentation/documentation.js
@@ -1,0 +1,25 @@
+import {
+  REQUEST_DOCUMENTATION,
+  RECEIVED_DOCUMENTATION,
+  RECEIVED_EMPTY_DOCUMENTATION,
+  FAILED_DOCUMENTATION,
+} from './documentation.actions'
+
+export const initialState = {
+  loaded: false,
+  data: {},
+}
+
+export default (state = initialState, { type, payload } = {}) => {
+  switch (type) {
+    case REQUEST_DOCUMENTATION:
+      return { ...initialState, loaded: false }
+    case RECEIVED_DOCUMENTATION:
+      return { data: payload, loaded: true }
+    case RECEIVED_EMPTY_DOCUMENTATION:
+    case FAILED_DOCUMENTATION:
+      return { ...initialState, loaded: true }
+    default:
+      return state
+  }
+}

--- a/src/gui/redux/documentation/documentation.selectors.js
+++ b/src/gui/redux/documentation/documentation.selectors.js
@@ -1,0 +1,9 @@
+import { createSelector } from 'reselect'
+
+const getDocumentation = state => state.documentation
+
+const getDocumentationData = createSelector(getDocumentation, doc => doc.data)
+
+const isLoading = createSelector(getDocumentation, doc => !doc.loaded)
+
+export { getDocumentation, getDocumentationData, isLoading }

--- a/src/gui/redux/documentation/index.js
+++ b/src/gui/redux/documentation/index.js
@@ -1,0 +1,3 @@
+export { default } from './documentation'
+export * from './documentation.actions'
+export * from './documentation.selectors'

--- a/src/gui/redux/store.js
+++ b/src/gui/redux/store.js
@@ -5,6 +5,7 @@ import thunk from 'redux-thunk'
 import router from './router'
 import model from './model'
 import docgen from './docgen'
+import documentation from './documentation'
 
 // initialize redux store
 const store = createStore(
@@ -12,6 +13,7 @@ const store = createStore(
     router: router.reducer,
     model,
     docgen,
+    documentation,
   }),
   composeWithDevTools(router.enhancer, applyMiddleware(thunk, router.middleware))
 )

--- a/src/gui/screens/documentation/documentation.container.js
+++ b/src/gui/screens/documentation/documentation.container.js
@@ -1,0 +1,20 @@
+import { connect } from 'react-redux'
+import loader from 'hoc-react-loader'
+import router from 'hoc-little-router'
+
+import { fetchDocumentation, getDocumentationData, isLoading } from '../../redux/documentation'
+import Documentation from './documentation'
+
+const mapState = state => ({
+  loaded: !isLoading(state),
+  content: getDocumentationData(state),
+})
+
+const mapDispatch = dispatch => ({
+  load: () => dispatch(fetchDocumentation()),
+})
+
+const loadable = loader()(Documentation)
+const routed = router('DOCUMENTATION')(loadable)
+
+export default connect(mapState, mapDispatch)(routed)

--- a/src/gui/screens/documentation/documentation.jsx
+++ b/src/gui/screens/documentation/documentation.jsx
@@ -1,12 +1,11 @@
 import React from 'react'
-import router from 'hoc-little-router'
 
-const Documentation = () => {
+const Documentation = ({ content }) => {
   return (
     <div>
-      Documentation
+      {content}
     </div>
   )
 }
 
-export default router('DOCUMENTATION')(Documentation)
+export default Documentation

--- a/src/gui/screens/documentation/documentation.jsx
+++ b/src/gui/screens/documentation/documentation.jsx
@@ -1,11 +1,18 @@
 import React from 'react'
+import PropTypes from 'prop-types'
+
+import styles from './documentation.styles'
 
 const Documentation = ({ content }) => {
   return (
-    <div>
+    <textarea className={styles.layout}>
       {content}
-    </div>
+    </textarea>
   )
+}
+
+Documentation.propTypes = {
+  content: PropTypes.string.isRequired,
 }
 
 export default Documentation

--- a/src/gui/screens/documentation/documentation.styles.js
+++ b/src/gui/screens/documentation/documentation.styles.js
@@ -1,0 +1,12 @@
+import { css } from 'glamor'
+
+const layout = css({
+  height: '100%',
+  maxHeight: '100%',
+  padding: '1em',
+  margin: '1em',
+  borderWidth: '1px',
+  outline: 'none',
+})
+
+export default { layout }

--- a/src/gui/screens/documentation/index.js
+++ b/src/gui/screens/documentation/index.js
@@ -1,1 +1,1 @@
-export { default } from './documentation'
+export { default } from './documentation.container'


### PR DESCRIPTION
_Display documentation in gui :_ 

- add **documentation** reducer, actions, selectors
- fetch markdown documentation through **`GET /api/doc?format=markdown`**
- display content in a simple `<textarea>`