### PR TITLE
:sparkles: save readme endpoint

### DIFF
--- a/src/script/server/readme/__snapshots__/readme.spec.js.snap
+++ b/src/script/server/readme/__snapshots__/readme.spec.js.snap
@@ -1,11 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`service/readme should generate component markdown if README.md file doesnt exist 1`] = `
+exports[`service/readme get readme file should generate component markdown if README.md file doesnt exist 1`] = `
 Array [
   Array [],
 ]
 `;
 
-exports[`service/readme should generate component markdown if README.md file doesnt exist 2`] = `"MARKDOWN CONTENT"`;
+exports[`service/readme get readme file should generate component markdown if README.md file doesnt exist 2`] = `"MARKDOWN CONTENT"`;
 
-exports[`service/readme should return README.md file content if exists 1`] = `"README CONTENT"`;
+exports[`service/readme get readme file should return README.md file content if exists 1`] = `"README CONTENT"`;
+
+exports[`service/readme save readme file should save README.md file with given content 1`] = `
+Array [
+  Array [
+    "/foo/bar/baz/README.md",
+    "content",
+  ],
+]
+`;

--- a/src/script/server/readme/__snapshots__/readme.spec.js.snap
+++ b/src/script/server/readme/__snapshots__/readme.spec.js.snap
@@ -18,3 +18,5 @@ Array [
   ],
 ]
 `;
+
+exports[`service/readme save readme file should throw the underlaying fs exception 1`] = `[Error: fs fails to write file]`;

--- a/src/script/server/readme/readme.api.js
+++ b/src/script/server/readme/readme.api.js
@@ -6,6 +6,13 @@ const get = {
   handler: () => service.get(),
 }
 
+const save = {
+  method: 'post',
+  path: 'readme',
+  handler: req => service.save(req.body),
+}
+
 module.exports = {
   get,
+  save,
 }

--- a/src/script/server/readme/readme.js
+++ b/src/script/server/readme/readme.js
@@ -20,6 +20,14 @@ const get = () => async (dispatch, getState) => {
   return markdown.generate()
 }
 
+const save = content => async (dispatch, getState) => {
+  const component = reducers.component.get()(getState())
+  const readmePath = path.resolve(component.path.absolute.dir, 'README.md')
+
+  await fs.writeFileAsync(readmePath, content)
+}
+
 module.exports = {
   get,
+  save,
 }

--- a/src/script/server/readme/readme.spec.js
+++ b/src/script/server/readme/readme.spec.js
@@ -76,5 +76,23 @@ describe('service/readme', () => {
       // asserts
       expect(fs.writeFileAsync.mock.calls).toMatchSnapshot()
     })
+
+    it('should throw the underlaying fs exception', async () => {
+      // mocks
+      fs.writeFileAsync.mockImplementation(jest.fn(() => {
+        throw new Error('fs fails to write file')
+      }))
+
+      // calls
+      let error = false
+      try {
+        await readme.save('content')(undefined, getState)
+      } catch (ex) {
+        error = ex
+      }
+
+      // assert
+      expect(error).toMatchSnapshot()
+    })
   })
 })

--- a/src/script/server/readme/readme.spec.js
+++ b/src/script/server/readme/readme.spec.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-jest.mock('fs', () => ({ readFileAsync: jest.fn() }))
+jest.mock('fs', () => ({ readFileAsync: jest.fn(), writeFileAsync: jest.fn() }))
 jest.mock('./markdown', () => ({ generate: jest.fn() }))
 
 const fs = require('fs')
@@ -14,52 +14,67 @@ const getState = () => ({
 })
 
 describe('service/readme', () => {
-  it('should return README.md file content if exists', async () => {
-    // mocks
-    fs.readFileAsync.mockImplementation(jest.fn(async () => 'README CONTENT'))
+  describe('get readme file', () => {
+    it('should return README.md file content if exists', async () => {
+      // mocks
+      fs.readFileAsync.mockImplementation(jest.fn(async () => 'README CONTENT'))
 
-    // calls
-    const content = await readme.get()(undefined, getState)
+      // calls
+      const content = await readme.get()(undefined, getState)
 
-    // asserts
-    expect(content).toMatchSnapshot()
+      // asserts
+      expect(content).toMatchSnapshot()
+    })
+
+    it('should generate component markdown if README.md file doesnt exist', async () => {
+      // mocks
+      fs.readFileAsync.mockImplementation(
+        jest.fn(async () => {
+          const error = { errno: -2 }
+          throw error
+        })
+      )
+      markdown.generate.mockImplementation(jest.fn(async () => 'MARKDOWN CONTENT'))
+
+      // calls
+      const content = await readme.get()(undefined, getState)
+
+      // asserts
+      expect(markdown.generate.mock.calls).toMatchSnapshot()
+      expect(content).toMatchSnapshot()
+    })
+
+    it('should throw an error when reading fs fails', async () => {
+      // mocks
+      fs.readFileAsync.mockImplementation(
+        jest.fn(async () => {
+          throw new Error('fs fails to read file')
+        })
+      )
+
+      // calls
+      let error = false
+      try {
+        await readme.get()(undefined, getState)
+      } catch (ex) {
+        error = true
+      }
+
+      // asserts
+      expect(error).toBe(true)
+    })
   })
 
-  it('should generate component markdown if README.md file doesnt exist', async () => {
-    // mocks
-    fs.readFileAsync.mockImplementation(
-      jest.fn(async () => {
-        const error = { errno: -2 }
-        throw error
-      })
-    )
-    markdown.generate.mockImplementation(jest.fn(async () => 'MARKDOWN CONTENT'))
+  describe('save readme file', () => {
+    it('should save README.md file with given content', async () => {
+      // mocks
+      fs.writeFileAsync.mockImplementation(jest.fn(async () => {}))
 
-    // calls
-    const content = await readme.get()(undefined, getState)
+      // calls
+      await readme.save('content')(undefined, getState)
 
-    // asserts
-    expect(markdown.generate.mock.calls).toMatchSnapshot()
-    expect(content).toMatchSnapshot()
-  })
-
-  it('should throw an error when reading fs fails', async () => {
-    // mocks
-    fs.readFileAsync.mockImplementation(
-      jest.fn(async () => {
-        throw new Error('fs fails to read file')
-      })
-    )
-
-    // calls
-    let error = false
-    try {
-      await readme.get()(undefined, getState)
-    } catch (ex) {
-      error = true
-    }
-
-    // asserts
-    expect(error).toBe(true)
+      // asserts
+      expect(fs.writeFileAsync.mock.calls).toMatchSnapshot()
+    })
   })
 })


### PR DESCRIPTION
**description**
`POST /api/readme` with the readme file in text/plain as body.

**to test it**
```bash
curl -H "Content-Type: text/plain" -X POST -d "My readme content" http://localhost:8080/api/readme
```